### PR TITLE
Need to define __STDC_FORMAT_MACROS for some glibc versions

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -22,6 +22,10 @@
 #else
 #include <sys/time.h>
 #include <sys/resource.h>
+// Get the standard printf format macros for C99 stdint types.
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 #include <cxxabi.h>
 #include <dlfcn.h>


### PR DESCRIPTION
Fix for https://github.com/nodejs/nodereport/issues/4. The compilation failure was caused by undefined macro  `PRIu64`. This macro is defined in the include file inttypes.h, but some levels of glibc required that `#define __STDC_FORMAT_MACROS` is also set, eg see http://en.cppreference.com/w/cpp/types/integer
