### PR TITLE
Fix nodereport requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 NodeReport*.txt
 npm-debug.log
 nodereport-*.tgz
+nodereport_test.log

--- a/test/test_1.js
+++ b/test/test_1.js
@@ -1,5 +1,5 @@
 // NodeReport API example
-var nodereport = require('nodereport');
+var nodereport = require('../');
 
 console.log('api_call.js: triggering a NodeReport via API call...');
 

--- a/test/test_2.js
+++ b/test/test_2.js
@@ -1,5 +1,5 @@
 // Testcase to produce an uncaught exception
-require('nodereport').setEvents("exception");
+require('../').setEvents("exception");
 
 console.log('exception.js: throwing an uncaught user exception....');
 

--- a/test/test_3.js
+++ b/test/test_3.js
@@ -1,5 +1,5 @@
 // Testcase to produce a fatal error (javascript heap OOM)
-require('nodereport').setEvents("fatalerror");
+require('../').setEvents("fatalerror");
 
 console.log('fatalerror.js: allocating excessive javascript heap memory....');
 var list = [];

--- a/test/test_4.js
+++ b/test/test_4.js
@@ -1,5 +1,5 @@
 // Testcase to loop in Javascript code
-require('nodereport').setEvents("signal");
+require('../').setEvents("signal");
 
 console.log('loop.js: going into loop now.... use kill -USR2 <pid> to trigger NodeReport');
 


### PR DESCRIPTION
The tests would only run when nodereport was itself git cloned into a directory called `node_modules`, tricking the require system into thinking nodereport was a dependency of itself.

Partially fixes #7 
