### PR TITLE
Prototype fix for failures in nodereport test #3 - do not land

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -436,7 +436,8 @@ static void PrintJavaScriptStack(FILE* fp, Isolate* isolate, DumpEvent event, co
     break;
   case kFatalError:
 #if NODE_VERSION_AT_LEAST(6, 0, 0)
-    if (!strncmp(location, "MarkCompactCollector", sizeof("MarkCompactCollector") - 1)) {
+    if ((!strncmp(location, "MarkCompactCollector", sizeof("MarkCompactCollector") - 1)) ||
+        (!strncmp(location, "Scavenger", sizeof("Scavenger") -1))) {
       fprintf(fp, "V8 running in GC - no stack trace available\n");
     } else {
       Message::PrintCurrentStackTrace(isolate, fp);


### PR DESCRIPTION
The v8 PrintCurrentStackTrace() API cannot be used to collect the JS stack if we are actually inside a v8 GC when the fatal error (and NodeReport) is triggered. This happens intermittently for OOM failures, and the API will crash or hang. The explanation is that objects are on the move, see https://groups.google.com/forum/#!topic/v8-dev/c6vGpNMScKU. The problem also shows up in the stderr failure messages from node, the usual JS stack trace is replaced by a "Cannot get stack trace in GC" message.

The workaround in nodereport is to detect that we are in GC and skip the stack trace. This PR adds another case to to the check we use to detect we are in GC.