### PR TITLE
Fix for failure in fatal error (OOM) test

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -439,15 +439,7 @@ static void PrintJavaScriptStack(FILE* fp, Isolate* isolate, DumpEvent event, co
     Message::PrintCurrentStackTrace(isolate, fp);
     break;
   case kFatalError:
-#if NODE_VERSION_AT_LEAST(6, 0, 0)
-    if (!strncmp(location, "MarkCompactCollector", sizeof("MarkCompactCollector") - 1)) {
-      fprintf(fp, "V8 running in GC - no stack trace available\n");
-    } else {
-      Message::PrintCurrentStackTrace(isolate, fp);
-    }
-#else
     fprintf(fp, "No stack trace available\n");
-#endif
     break;
   case kSignal_JS:
   case kSignal_UV:


### PR DESCRIPTION
Fix for https://github.com/nodejs/nodereport/issues/12

On v6.9.1 we get a second OOM in v8 if we call the v8 stacktrace API in the fatal error (OOM) scenario. It worked OK on v6.3.0. Fix is to remove the call for now, for the fatal error (OOM) scenario. There was an additional check to avoid the call if we failed actually inside GC, this is also removed as it is now redundant.

This means we won't provide a JS stacktrace in the NodeReport for this particular scenario.  The v8 stderr output does show a single JS frame, so we may be able to obtain that for nodereport via another route at some point. Alternatively we can investigate why the v8 API is failing and see if that can be improved.