### PR TITLE
Add support for nodereport on AIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes JavaScript and native stack traces, heap statistics,
 platform information and resource usage etc. With the report enabled,
 reports can be triggered on unhandled exceptions, fatal errors, signals
 and calls to a JavaScript API. The module supports Node.js v4, v6 and v7
-on Linux, MacOS and Windows.
+on Linux, MacOS, Windows and AIX.
 
 Usage:
 

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -5,7 +5,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/types.h>
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_AIX)
 #include <features.h>
 #endif
 #endif


### PR DESCRIPTION
1. features.h and execinfo.h do not exist on AIX
2. backtrace() API is not available, native stacks disabled in nodereport for now
3. ru_utime.tv_usec is int not long (same as OSX)
4. ulimit RLIMIT_MEMLOCK is not available on AIX
5. PRIu64 macro is not available in gcc on AIX

@richardlau FYI