### PR TITLE
Improvement to Windows version reporting

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,8 +10,8 @@
           "cflags": [ "-g", "-O2", "-std=c++11", ],
         }],
         ["OS=='win'", {
-          "libraries": [ "dbghelp.lib" ],
-          "dll_files": [ "dbghelp.dll" ],
+          "libraries": [ "dbghelp.lib", "Netapi32.lib" ],
+          "dll_files": [ "dbghelp.dll", "Netapi32.dll" ],
         }],
       ],
     },


### PR DESCRIPTION
Changes detection of Windows version from using the helper functions in [VersionHelpers.h](https://msdn.microsoft.com/en-us/library/windows/desktop/dn424972%28v=vs.85%29.aspx) to use [NetServerGetInfo](https://msdn.microsoft.com/en-us/library/windows/desktop/aa370624%28v=vs.85%29.aspx) instead.

[IsWindows10OrGreater](https://msdn.microsoft.com/en-us/library/windows/desktop/dn905474%28v=vs.85%29.aspx) requires Windows SDK 10 (I was getting compilation errors because it was a) spelt incorrectly and b) I didn't have Windows SDK 10 installed even though I was compiling with Visual Studio 2015). It also doesn't always return true even if the system is Windows 10:
`Applications not manifested for Windows 10 return false, even if the current operating system version is Windows 10.`

Mappings of major and minor versions reported by `NetServerGetInfo` to more common Windows version names are based on ~~[env plugin from omr-agentcore](https://github.com/RuntimeTools/omr-agentcore/blob/3.0.10/src/ibmras/monitoring/plugins/common/environment/envplugin.cpp#L493)~~ [this table on MSDN](https://msdn.microsoft.com/en-gb/library/windows/desktop/ms724832(v=vs.85).aspx) -- I've tested on Windows 7, Windows 10 and Server 2016 and the generated report contains the expected values. 

Operating system|Version number
---|---
Windows 10|10.0
Windows Server 2016|10.0
Windows 8.1|6.3
Windows Server 2012 R2|6.3
Windows 8|6.2
Windows Server 2012|6.2
Windows 7|6.1
Windows Server 2008 R2|6.1
Windows Server 2008|6.0
Windows Vista|6.0
Windows Server 2003 R2|5.2
Windows Server 2003|5.2
Windows XP 64-Bit Edition|5.2
Windows XP|5.1
Windows 2000|5.0

@rnchamberlain 