### PR TITLE
Fix test-exception.js for PPC

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -17,6 +17,14 @@ exports.findReports = (pid) => {
   return files.filter((file) => filePattern.test(file));
 };
 
+exports.isPPC = () => {
+  return process.arch.startsWith('ppc');
+};
+
+exports.isWindows = () => {
+  return process.platform === 'win32';
+};
+
 exports.validate = (t, report, pid) => {
   t.test('Validating ' + report, (t) => {
     fs.readFile(report, (err, data) => {

--- a/test/test-exception.js
+++ b/test/test-exception.js
@@ -22,8 +22,9 @@ if (process.argv[2] === 'child') {
 
   const child = spawn(process.execPath, [__filename, 'child']);
   child.on('exit', (code, signal) => {
-    const expectedExitCode = process.platform === 'win32' ? 0xC0000005 : null;
-    const expectedSignal = process.platform === 'win32' ? null : 'SIGILL';
+    const expectedExitCode = common.isWindows() ? 0xC0000005 : null;
+    const expectedSignal = common.isWindows() ? null : 
+                           common.isPPC() ? 'SIGTRAP' : 'SIGILL';
     tap.plan(4);
     tap.equal(code, expectedExitCode, 'Process should not exit cleanly');
     tap.equal(signal, expectedSignal,

--- a/test/test-signal.js
+++ b/test/test-signal.js
@@ -36,7 +36,7 @@ if (process.argv[2] === 'child') {
   const fork = require('child_process').fork;
   const tap = require('tap');
 
-  if (process.platform === 'win32') {
+  if (common.isWindows()) {
     tap.fail('Unsupported on Windows', { skip: true });
     return;
   }


### PR DESCRIPTION
On PPC architectures, `--abort_on_uncaught_exception` (currently set by nodereport for the `exception` event, see #6) exits with SIGTRAP instead of SIGILL (nodejs/node#3239). This PR fixes the `test-exception.js` testcase for the current behaviour.