### PR TITLE
Fix for clang warning: libstdc++ is deprecated

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,12 @@
           "libraries": [ "dbghelp.lib", "Netapi32.lib" ],
           "dll_files": [ "dbghelp.dll", "Netapi32.dll" ],
         }],
+        ["OS=='mac'", {
+          "xcode_settings": {
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+          }
+        }],
       ],
     },
     {


### PR DESCRIPTION
When installing the nodereport module on macOS 10.12 (Sierra), the clang deprecation warning above is output during npm install. The fix is to override the std c++ library inherited from node, so that the module is linked to libc++

Uses known solution described here: https://github.com/nodejs/nan/issues/606

Fixes https://github.com/nodejs/nodereport/issues/22