### PR TITLE
Add command line to nodereport.

### DIFF
--- a/src/module.cc
+++ b/src/module.cc
@@ -303,6 +303,7 @@ void Initialize(v8::Local<v8::Object> exports) {
 
   SetLoadTime();
   SetVersionString(isolate);
+  SetCommandLine();
 
   const char* verbose_switch = secure_getenv("NODEREPORT_VERBOSE");
   if (verbose_switch != nullptr) {

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -313,37 +313,37 @@ void SetLoadTime() {
  * Function to save the process command line
  *******************************************************************************/
 void SetCommandLine() {
-  #ifdef __linux__
-    // Read the command line from /proc/self/cmdline
-    char buf[64];
-    FILE* cmdline_fd = fopen("/proc/self/cmdline", "r");
-    if (cmdline_fd == nullptr) {
-      return;
-    }
-    commandline_string = "";
-    int bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
-    while (bytesread > 0) {
-      for (int i = 0; i < bytesread; i++) {
-        // Arguments are null separated.
-        if (buf[i] == '\0') {
-          commandline_string += " ";
-        } else {
-          commandline_string += buf[i];
-        }
+#ifdef __linux__
+  // Read the command line from /proc/self/cmdline
+  char buf[64];
+  FILE* cmdline_fd = fopen("/proc/self/cmdline", "r");
+  if (cmdline_fd == nullptr) {
+    return;
+  }
+  commandline_string = "";
+  int bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
+  while (bytesread > 0) {
+    for (int i = 0; i < bytesread; i++) {
+      // Arguments are null separated.
+      if (buf[i] == '\0') {
+        commandline_string += " ";
+      } else {
+        commandline_string += buf[i];
       }
-      bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
     }
-    fclose(cmdline_fd);
-  #elif __APPLE__
-    char **argv = *_NSGetArgv();
-    int argc = *_NSGetArgc();
+    bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
+  }
+  fclose(cmdline_fd);
+#elif __APPLE__
+  char **argv = *_NSGetArgv();
+  int argc = *_NSGetArgc();
 
-    commandline_string = "";
-    std::string seperator = "";
-    for (int i = 0; i < argc; i++) {
-      commandline_string += seperator + argv[i];
-      seperator = " ";
-    }
+  commandline_string = "";
+  std::string seperator = "";
+  for (int i = 0; i < argc; i++) {
+    commandline_string += seperator + argv[i];
+    seperator = " ";
+  }
 #elif _AIX
   // Read the command line from /proc/self/cmdline
   char procbuf[64];

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -364,7 +364,9 @@ void SetCommandLine() {
       separator = " ";
     }
   }
-#endif // _AIX
+#elif _WIN32
+  commandline_string = GetCommandLine();
+#endif
 }
 
 /*******************************************************************************
@@ -541,7 +543,7 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
  ******************************************************************************/
 static void PrintCommandLine(FILE* fp) {
   if (commandline_string != "") {
-    fprintf(fp, "Command line arguments: %s\n", commandline_string.c_str());
+    fprintf(fp, "Command line: %s\n", commandline_string.c_str());
   }
 }
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -339,10 +339,10 @@ void SetCommandLine() {
   int argc = *_NSGetArgc();
 
   commandline_string = "";
-  std::string seperator = "";
+  std::string separator = "";
   for (int i = 0; i < argc; i++) {
-    commandline_string += seperator + argv[i];
-    seperator = " ";
+    commandline_string += separator + argv[i];
+    separator = " ";
   }
 #elif _AIX
   // Read the command line from /proc/self/cmdline
@@ -357,11 +357,11 @@ void SetCommandLine() {
   fclose(psinfo_fd);
   if (bytesread == sizeof(psinfo_t)) {
     commandline_string = "";
-    std::string seperator = "";
+    std::string separator = "";
     char **argv = *((char ***) info.pr_argv);
     for (uint32_t i = 0; i < info.pr_argc; i++) {
-      commandline_string += seperator + argv[i];
-      seperator = " ";
+      commandline_string += separator + argv[i];
+      separator = " ";
     }
   }
 #endif // _AIX

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -29,6 +29,8 @@
 #include <dlfcn.h>
 #ifndef _AIX
 #include <execinfo.h>
+#else
+#include <sys/procfs.h>
 #endif
 #include <sys/utsname.h>
 #endif
@@ -39,6 +41,11 @@
 
 #if !defined(UNKNOWN_NODEVERSION_STRING)
 #define UNKNOWN_NODEVERSION_STRING "Unable to determine Node.js version\n"
+#endif
+
+#ifdef __APPLE__
+// Include _NSGetArgv and _NSGetArgc for command line arguments.
+#include <crt_externs.h>
 #endif
 
 #ifndef _WIN32
@@ -58,6 +65,7 @@ using v8::String;
 using v8::V8;
 
 // Internal/static function declarations
+static void PrintCommandLine(FILE* fp);
 static void PrintVersionInformation(FILE* fp, Isolate* isolate);
 static void PrintJavaScriptStack(FILE* fp, Isolate* isolate, DumpEvent event, const char* location);
 static void PrintStackFromStackTrace(FILE* fp, Isolate* isolate, DumpEvent event);
@@ -77,6 +85,7 @@ static bool report_active = false; // recursion protection
 static char report_filename[NR_MAXNAME + 1] = "";
 static char report_directory[NR_MAXPATH + 1] = ""; // defaults to current working directory
 static std::string version_string = UNKNOWN_NODEVERSION_STRING;
+static std::string commandline_string = "";
 #ifdef _WIN32
 static SYSTEMTIME loadtime_tm_struct; // module load time
 #else  // UNIX, OSX
@@ -299,6 +308,65 @@ void SetLoadTime() {
   localtime_r(&time_val.tv_sec, &loadtime_tm_struct);
 #endif
 }
+
+/*******************************************************************************
+ * Function to save the process command line
+ *******************************************************************************/
+void SetCommandLine() {
+  #ifdef __linux__
+    // Read the command line from /proc/self/cmdline
+    char buf[64];
+    FILE* cmdline_fd = fopen("/proc/self/cmdline", "r");
+    if (cmdline_fd == nullptr) {
+      return;
+    }
+    commandline_string = "";
+    int bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
+    while (bytesread > 0) {
+      for (int i = 0; i < bytesread; i++) {
+        // Arguments are null separated.
+        if (buf[i] == '\0') {
+          commandline_string += " ";
+        } else {
+          commandline_string += buf[i];
+        }
+      }
+      bytesread = fread(buf, 1, sizeof(buf), cmdline_fd);
+    }
+    fclose(cmdline_fd);
+  #elif __APPLE__
+    char **argv = *_NSGetArgv();
+    int argc = *_NSGetArgc();
+
+    commandline_string = "";
+    std::string seperator = "";
+    for (int i = 0; i < argc; i++) {
+      commandline_string += seperator + argv[i];
+      seperator = " ";
+    }
+#elif _AIX
+  // Read the command line from /proc/self/cmdline
+  char procbuf[64];
+  snprintf(procbuf, sizeof(procbuf), "/proc/%d/psinfo", getpid());
+  FILE* psinfo_fd = fopen(procbuf, "r");
+  if (psinfo_fd == nullptr) {
+    return;
+  }
+  psinfo_t info;
+  int bytesread = fread(&info, 1, sizeof(psinfo_t), psinfo_fd);
+  fclose(psinfo_fd);
+  if (bytesread == sizeof(psinfo_t)) {
+    commandline_string = "";
+    std::string seperator = "";
+    char **argv = *((char ***) info.pr_argv);
+    for (uint32_t i = 0; i < info.pr_argc; i++) {
+      commandline_string += seperator + argv[i];
+      seperator = " ";
+    }
+  }
+#endif // _AIX
+}
+
 /*******************************************************************************
  * Main API function to write a NodeReport to file.
  *
@@ -311,7 +379,7 @@ void SetLoadTime() {
  ******************************************************************************/
 void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, char* name) {
   // Recursion check for NodeReport in progress, bail out
-  if (report_active) return; 
+  if (report_active) return;
   report_active = true;
 
   // Obtain the current time and the pid (platform dependent)
@@ -414,6 +482,10 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
   fprintf(fp, "Process ID: %d\n", pid);
   fflush(fp);
 
+  // Print out the command line.
+  PrintCommandLine(fp);
+  fflush(fp);
+
   // Print Node.js and OS version information
   PrintVersionInformation(fp, isolate);
   fflush(fp);
@@ -461,6 +533,16 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
     snprintf(name, NR_MAXNAME + 1, "%s", filename);  // return the NodeReport file name
   }
   report_active = false;
+}
+
+/*******************************************************************************
+ * Function to print process command line.
+ *
+ ******************************************************************************/
+static void PrintCommandLine(FILE* fp) {
+  if (commandline_string != "") {
+    fprintf(fp, "Command line arguments: %s\n", commandline_string.c_str());
+  }
 }
 
 /*******************************************************************************
@@ -688,7 +770,7 @@ void PrintNativeStack(FILE* fp) {
   SymInitialize(hProcess, nullptr, TRUE);
 
   WORD numberOfFrames = CaptureStackBackTrace(2, 64, frames, nullptr);
-  
+
   // Walk the frames printing symbolic information if available
   for (int i = 0; i < numberOfFrames; i++) {
     DWORD64 dwOffset64 = 0;

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -44,6 +44,7 @@ unsigned int ProcessNodeReportVerboseSwitch(const char* args);
 
 void SetLoadTime();
 void SetVersionString(Isolate* isolate);
+void SetCommandLine();
 
 // Local implementation of secure_getenv()
 inline const char* secure_getenv(const char* key) {

--- a/test/common.js
+++ b/test/common.js
@@ -37,7 +37,7 @@ exports.validate = (t, report, options) => {
                                options.expectedVersions || nodeComponents :
                                nodeComponents;
       var plan = REPORT_SECTIONS.length + nodeComponents.length + 2;
-      if( options.commandline ) plan++;
+      if (options.commandline) plan++;
       t.plan(plan);
       // Check all sections are present
       REPORT_SECTIONS.forEach((section) => {
@@ -47,7 +47,7 @@ exports.validate = (t, report, options) => {
 
       // Check NodeReport header section
       const nodeReportSection = getSection(reportContents, 'NodeReport');
-      t.contains(nodeReportSection, new RegExp('Process ID: ' + pid),
+      t.match(nodeReportSection, new RegExp('Process ID: ' + pid),
               'NodeReport section contains expected process ID');
       if (options && options.expectNodeVersion === false) {
         t.match(nodeReportSection, /Unable to determine Node.js version/,
@@ -59,10 +59,11 @@ exports.validate = (t, report, options) => {
       }
       if (options && options.commandline) {
         if (this.isWindows()) {
-          // On Windows we need to strip out double quotes from the command line in the
-          // report, and escape the backslashes in the regex comparison string.
+          // On Windows we need to strip double quotes from the command line in
+          // the report, and escape backslashes in the regex comparison string.
           t.match(nodeReportSection.replace(/"/g,''),
-                  new RegExp('Command line: ' + (options.commandline).replace(/\\/g,'\\\\')),
+                  new RegExp('Command line: '
+                             + (options.commandline).replace(/\\/g,'\\\\')),
                   'Checking report contains expected command line');
         } else {
           t.match(nodeReportSection,

--- a/test/common.js
+++ b/test/common.js
@@ -36,9 +36,9 @@ exports.validate = (t, report, options) => {
       const expectedVersions = options ?
                                options.expectedVersions || nodeComponents :
                                nodeComponents;
-      const plan = REPORT_SECTIONS.length + nodeComponents.length + 2;
+      var plan = REPORT_SECTIONS.length + nodeComponents.length + 2;
+      if( options.commandline ) plan++;
       t.plan(plan);
-
       // Check all sections are present
       REPORT_SECTIONS.forEach((section) => {
         t.match(reportContents, new RegExp('==== ' + section),
@@ -47,7 +47,7 @@ exports.validate = (t, report, options) => {
 
       // Check NodeReport section
       const nodeReportSection = getSection(reportContents, 'NodeReport');
-      t.match(nodeReportSection, new RegExp('Process ID: ' + pid),
+      t.contains(nodeReportSection, new RegExp('Process ID: ' + pid),
               'NodeReport section contains expected process ID');
       if (options && options.expectNodeVersion === false) {
         t.match(nodeReportSection, /Unable to determine Node.js version/,
@@ -56,6 +56,10 @@ exports.validate = (t, report, options) => {
         t.match(nodeReportSection,
                 new RegExp('Node.js version: ' + process.version),
                 'NodeReport section contains expected Node.js version');
+      }
+      if (options && options.commandline) {
+        t.match(nodeReportSection, new RegExp('Command line arguments: ' + options.commandline),
+                'NodeReport section contains expected command line');
       }
       nodeComponents.forEach((c) => {
         if (c !== 'node') {

--- a/test/common.js
+++ b/test/common.js
@@ -45,7 +45,7 @@ exports.validate = (t, report, options) => {
                 'Checking report contains ' + section + ' section');
       });
 
-      // Check NodeReport section
+      // Check NodeReport header section
       const nodeReportSection = getSection(reportContents, 'NodeReport');
       t.contains(nodeReportSection, new RegExp('Process ID: ' + pid),
               'NodeReport section contains expected process ID');
@@ -58,8 +58,17 @@ exports.validate = (t, report, options) => {
                 'NodeReport section contains expected Node.js version');
       }
       if (options && options.commandline) {
-        t.match(nodeReportSection, new RegExp('Command line arguments: ' + options.commandline),
-                'NodeReport section contains expected command line');
+        if (this.isWindows()) {
+          // On Windows we need to strip out double quotes from the command line in the
+          // report, and escape the backslashes in the regex comparison string.
+          t.match(nodeReportSection.replace(/"/g,''),
+                  new RegExp('Command line: ' + (options.commandline).replace(/\\/g,'\\\\')),
+                  'Checking report contains expected command line');
+        } else {
+          t.match(nodeReportSection,
+                  new RegExp('Command line: ' + options.commandline),
+                  'Checking report contains expected command line');
+        }
       }
       nodeComponents.forEach((c) => {
         if (c !== 'node') {

--- a/test/test-api-bad-processobj.js
+++ b/test/test-api-bad-processobj.js
@@ -18,7 +18,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    const validateOpts = { pid: child.pid, expectedVersions: [] };
+    const validateOpts = { pid: child.pid, expectedVersions: [],
+      commandline: child.spawnargs.join(' '), };
     common.validate(tap, report, validateOpts);
   });
 }

--- a/test/test-api-bad-processversion.js
+++ b/test/test-api-bad-processversion.js
@@ -18,7 +18,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    const validateOpts = { pid: child.pid, expectNodeVersion: true };
+    const validateOpts = { pid: child.pid, expectNodeVersion: true,
+      commandline: child.spawnargs.join(' '), };
     common.validate(tap, report, validateOpts);
   });
 }

--- a/test/test-api-bad-processversions.js
+++ b/test/test-api-bad-processversions.js
@@ -19,7 +19,8 @@ if (process.argv[2] === 'child') {
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
     const validateOpts = { pid: child.pid,
-      expectedVersions: Object.keys(process.versions).filter((c) => c !== 'uv')
+      expectedVersions: Object.keys(process.versions).filter((c) => c !== 'uv'),
+      commandline: child.spawnargs.join(' ')
     };
     common.validate(tap, report, validateOpts);
   });

--- a/test/test-api-nohooks.js
+++ b/test/test-api-nohooks.js
@@ -17,6 +17,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid});
+    common.validate(tap, report, {pid: child.pid,
+      commandline: child.spawnargs.join(' ')
+    });
   });
 }

--- a/test/test-api-noversioninfo.js
+++ b/test/test-api-noversioninfo.js
@@ -22,7 +22,8 @@ if (process.argv[2] === 'child') {
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
     const validateOpts = { pid: child.pid, expectNodeVersion: false,
-      expectedVersions: [] };
+      expectedVersions: [], commandline: child.spawnargs.join(' ')
+    };
     common.validate(tap, report, validateOpts);
   });
 }

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -16,6 +16,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid});
+    common.validate(tap, report, {pid: child.pid,
+      commandline: child.spawnargs.join(' ')
+    });
   });
 }

--- a/test/test-exception.js
+++ b/test/test-exception.js
@@ -32,6 +32,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid});
+    common.validate(tap, report, {pid: child.pid,
+      commandline: child.spawnargs.join(' ')
+    });
   });
 }

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -28,6 +28,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid});
+    common.validate(tap, report, {pid: child.pid,
+      commandline: child.spawnargs.join(' ')
+    });
   });
 }

--- a/test/test-signal.js
+++ b/test/test-signal.js
@@ -59,6 +59,8 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid});
+    common.validate(tap, report, {pid: child.pid,
+      commandline: child.spawnargs.join(' ')
+    });
   });
 }


### PR DESCRIPTION
This patch adds the command line used to start the process to nodereport.
It's based off https://github.com/rnchamberlain/nodereport/tree/clang_warning so it could be built and tested on Mac. It should merge cleanly once that has been landed.

One line is added to the NodeReport file. Sample output from a test script that generates a report:

`> node --no-warnings my_application.js -a an_argument file.txt`

First part of the generated NodeReport file:
```
================================================================================
==== NodeReport ================================================================

Event: JavaScript API, location: "TriggerReport"
Filename: NodeReport.20161216.145623.6353.001.txt
Dump event time:  2016/12/16 14:56:23
Module load time: 2016/12/16 14:56:23
Process ID: 6353
Command line arguments: node --no-warnings my_application.js -a an_argument file.txt

Node.js version: v6.5.0
```