### PR TITLE
Add the list of library files loaded by the process to nodereport.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,8 +10,8 @@
           "cflags": [ "-g", "-O2", "-std=c++11", ],
         }],
         ["OS=='win'", {
-          "libraries": [ "dbghelp.lib", "Netapi32.lib" ],
-          "dll_files": [ "dbghelp.dll", "Netapi32.dll" ],
+          "libraries": [ "dbghelp.lib", "Netapi32.lib", "PsApi.lib" ],
+          "dll_files": [ "dbghelp.dll", "Netapi32.dll", "PsApi.dll" ],
         }],
         ["OS=='mac'", {
           "xcode_settings": {

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -1104,7 +1104,7 @@ static void PrintLoadedLibraries(FILE* fp, Isolate* isolate) {
     return;
   }
   // Get a list of all the modules in this process
-  DWORD size_1, size_2;
+  DWORD size_1 = 0, size_2 = 0;
   // First call to get the size of module array needed
   if (EnumProcessModules(process_handle, NULL, 0, &size_1)) {
     HMODULE* modules = (HMODULE*) malloc(size_1);
@@ -1113,11 +1113,13 @@ static void PrintLoadedLibraries(FILE* fp, Isolate* isolate) {
     }
     // Second call to populate the module array
     if (EnumProcessModules(process_handle, modules, size_1, &size_2)) {
-      for (int i=0; i < size_1/sizeof(HMODULE) && i < size_2/sizeof(HMODULE); i++) {
+      for (int i = 0;
+           i < (size_1 / sizeof(HMODULE)) && i < (size_2 / sizeof(HMODULE));
+           i++) {
         TCHAR module_name[MAX_PATH];
         // Obtain and print the full pathname for each module
         if (GetModuleFileNameEx(process_handle, modules[i], module_name,
-                                sizeof(module_name)/sizeof(TCHAR))) {
+                                sizeof(module_name) / sizeof(TCHAR))) {
           fprintf(fp,"  %s\n", module_name);
         }
       }

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -1108,6 +1108,9 @@ static void PrintLoadedLibraries(FILE* fp, Isolate* isolate) {
   // First call to get the size of module array needed
   if (EnumProcessModules(process_handle, NULL, 0, &size_1)) {
     HMODULE* modules = (HMODULE*) malloc(size_1);
+    if (modules == NULL) {
+      return;  // bail out if malloc failed
+    }
     // Second call to populate the module array
     if (EnumProcessModules(process_handle, modules, size_1, &size_2)) {
       for (int i=0; i < size_1/sizeof(HMODULE) && i < size_2/sizeof(HMODULE); i++) {

--- a/test/common.js
+++ b/test/common.js
@@ -36,7 +36,7 @@ exports.validate = (t, report, options) => {
       const expectedVersions = options ?
                                options.expectedVersions || nodeComponents :
                                nodeComponents;
-      var plan = REPORT_SECTIONS.length + nodeComponents.length + 2;
+      var plan = REPORT_SECTIONS.length + nodeComponents.length + 3;
       if (options.commandline) plan++;
       t.plan(plan);
       // Check all sections are present
@@ -88,6 +88,11 @@ exports.validate = (t, report, options) => {
       t.match(nodeReportSection,
               new RegExp('NodeReport version: ' + nodereportMetadata.version),
               'NodeReport section contains expected NodeReport version');
+      const sysInfoSection = getSection(reportContents, 'System Information');
+      // Find a line which ends with /api.node or \api.node (Unix or Windows paths.)
+      // to see if the library for node report was loaded.
+      t.match(sysInfoSection, /  .*[\/|\\]api\.node/,
+        'System Information section contains nodereport library.');
     });
   });
 };

--- a/test/common.js
+++ b/test/common.js
@@ -89,9 +89,10 @@ exports.validate = (t, report, options) => {
               new RegExp('NodeReport version: ' + nodereportMetadata.version),
               'NodeReport section contains expected NodeReport version');
       const sysInfoSection = getSection(reportContents, 'System Information');
-      // Find a line which ends with /api.node or \api.node (Unix or Windows paths.)
-      // to see if the library for node report was loaded.
-      t.match(sysInfoSection, /  .*[\/|\\]api\.node/,
+      // Find a line which ends with "/api.node" or "\api.node"
+      // (Unix or Windows paths) to see if the library for node report was
+      // loaded.
+      t.match(sysInfoSection, /  .*(\/|\\)api\.node/,
         'System Information section contains nodereport library.');
     });
   });


### PR DESCRIPTION
This pull request is for issue https://github.com/nodejs/nodereport/issues/19 and adds an extra section to the System Information nodereport provides that shows the libraries loaded by the application. This allows the user to identify any native libraries loaded by node modules as well as any other system libraries that have been loaded by node.

It provides the information reported by the operating system. This is similar to the output of ldd however it includes libraries loaded at runtime rather than just those that the executable is linked against.

This first implementation supports Linux, Mac and AIX. I will ask @rnchamberlain if he can push an update to this branch to provide Windows support.

The output looks like this (Mac OSX sample):

```
Loaded Libraries
  /Users/hhellyer/work/node-sdks/node-v6.5.0-darwin-x64/bin/node
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /usr/lib/libSystem.B.dylib
  /usr/lib/libstdc++.6.dylib
  /usr/lib/libDiagnosticMessagesClient.dylib
  ...
  /usr/lib/libc++abi.dylib
  /usr/lib/libc++.1.dylib
  /Users/hhellyer/work/consumability/node/testscripts/node_modules/nodereport/api.node
```




