### PR TITLE
docs: AIX supports triggering on USR2 signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ node -r nodereport app.js
 ```
 A NodeReport will be triggered automatically on unhandled exceptions and fatal
 error events (for example out of memory errors), and can also be triggered
-by sending a USR2 signal to a Node.js process (Linux/MacOS only).
+by sending a USR2 signal to a Node.js process (AIX/Linux/MacOS only).
 
 A NodeReport can also be triggered via an API call from a JavaScript
 application.


### PR DESCRIPTION
Looks like we missed a bit in `README.md` when adding AIX support. 