### PR TITLE
aix: skip command line check for test-fatal-error

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -19,6 +19,10 @@ exports.findReports = (pid) => {
   return files.filter((file) => filePattern.test(file));
 };
 
+exports.isAIX = () => {
+  return process.platform === 'aix';
+};
+
 exports.isPPC = () => {
   return process.arch.startsWith('ppc');
 };

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -28,8 +28,12 @@ if (process.argv[2] === 'child') {
     const reports = common.findReports(child.pid);
     tap.equal(reports.length, 1, 'Found reports ' + reports);
     const report = reports[0];
-    common.validate(tap, report, {pid: child.pid,
-      commandline: child.spawnargs.join(' ')
-    });
+    const options = {pid: child.pid};
+    // Node.js currently overwrites the command line on AIX
+    // https://github.com/nodejs/node/issues/10607
+    if (!common.isAIX()) {
+      options.commandline = child.spawnargs.join(' ');
+    }
+    common.validate(tap, report, options);
   });
 }


### PR DESCRIPTION
See #34 -- Node.js currently rewrites the process command line on AIX (nodejs/node#10607). This is causing a test failure on AIX:

```
test/test-fatal-error.js ............................ 17/18
  Validating NodeReport.20170120.070345.1245636.001.txt
  not ok Checking report contains expected command line
    found: >-
      Event: Allocation failed - process out of memory, location:
      "CALL_AND_RETRY_LAST"

      Filename: NodeReport.20170120.070345.1245636.001.txt

      Dump event time:  2017/01/20 07:03:45

      Module load time: 2017/01/20 07:03:45

      Process ID: 1245636

      Command line: /tmp/usenode.riclau/node-v4.7.2-aix-ppc64/bin/node
      /home/users/riclau/sandbox/github/nodereport/test/test-fatal-error.js child
      child


      Node.js version: v4.7.2

      (ares: 1.10.1-DEV, http_parser: 2.7.0, icu: 56.1, modules: 46, openssl:
      1.0.2j,
       uv: 1.9.1, v8: 4.5.103.43, zlib: 1.2.8)

      NodeReport version: 1.0.7 (built against Node.js v4.7.2)


      OS version: AIX 1 6


      Machine: dal-pax 00F460A94C00
    pattern: >-
      /Command line: \/tmp\/usenode.riclau\/node-v4.7.2-aix-ppc64\/bin\/node
      --max-old-space-size=20
      \/home\/users\/riclau\/sandbox\/github\/nodereport\/test\/test-fatal-error.js
      child/
    at:
      line: 69
      column: 13
      file: test/common.js
    stack: |
      test/common.js:69:13
      FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
    source: |
      t.match(nodeReportSection,

```

The behaviour may eventually be fixed if libuv/libuv#1187 lands but we want the tests to pass on the existing LTS releases so skip the command line check in `test-fatal-error.js` on AIX.
